### PR TITLE
English language changes to HostBasedAuth_en.md

### DIFF
--- a/HostBasedAuth_en.md
+++ b/HostBasedAuth_en.md
@@ -26,13 +26,13 @@ repo repo1
 ~~~
 the repo is:
 * readable from the addresses 10.11.12.13 and 10.11.12.14
-* writable from any address that reverse-resolve to HOST.DOMAIN
-* writable from any address that reverse-resolve to HOSTNAME<.ANYDOMAIN>
+* writable from any address that reverse-resolves to HOST.DOMAIN
+* writable from any address that reverse-resolves to HOSTNAME<.ANYDOMAIN>
 
-It is not required to define users and mappings for reader, writer and enforcer
+You need not define users and mappings for reader, writer and enforcer
 privileges for each repo. This example is only to show that this is possible.
 
-The gitolite verb create (used to create wild-repos) and those associate with
+The gitolite verb 'create' (used to create wild-repos) and those associate with
 git commands (git-upload-pack, git-receive-pack, git-upload-archive) are all
 supported. Here is a complete example:
 
@@ -118,8 +118,8 @@ git commit -am "initial"
     ~~~
 
 * For each repo:
-    * a user must be authorized according to needed access
-    * `map-anonhttp` option defines a autorized hosts or IPs for which `anonhttp` is
+    * a user must be authorized according to their needed access
+    * The `map-anonhttp` option defines autorized hosts or IPs for which `anonhttp` is
       replaced with this user
 
 ### anonhttp
@@ -132,8 +132,8 @@ The default value is `%RC{HTTP_ANON_USER}` or `anonhttp` in this order.
 
 ### option map-anonhttp
 
-This option defines a mapping between a user and a list of IP addresses, IP
-address class, fully qualified hosts, domains, or hosts for which `anonhttp` is
+This option defines a mapping between a user and a list of IP addresses, fully 
+qualified hosts, domains, or hosts; or an IP address classs for which `anonhttp` is
 replaced with the user.
 
 Examples:
@@ -154,9 +154,10 @@ equivalent to `.domain` and `hostname`, respectively.
 
 ### option match-repo
 
-This option matches a host based on the name of the repo. First, the
-repo name is matched with the match-repo regex. If successful, the host is built
-from capture groups from the regex.
+This option matches a host based on the name of the repo. It must be used in 
+conjunction with 'map-anonhttp'. First, the repo name is matched with the 
+match-repo regex. The host is built from capture groups from the regex and
+can be used in subsequent 'map-anonhttp' options.
 
 Example:
 ~~~

--- a/HostBasedAuth_en.md
+++ b/HostBasedAuth_en.md
@@ -5,12 +5,12 @@ translate afterwards. This file may not be up to date wrt the french one.
 
 # HostBasedAuth trigger
 
-This trigger enable host based authentication. Host ip, name or fqdn can be used
+This trigger enables host based authentication. Host ip, name or fqdn can be used
 for authentication. This trigger is designed to be used in smart-http mode.
 
 For each repo:
 * some specific users must be authorized (name doesn't matter)
-* for each of these users, an option define autorized hosts or IPs
+* for each of these users, an option defines autorized hosts or IPs
 * if the repo is accessed anonymously with user `anonhttp` from an authorized
   hosts, then the corresponding user is selected
 
@@ -101,7 +101,7 @@ git commit -am "initial"
 ## Configuration
 
 * IMPORTANT: in smart-http mode, you have to authorize the user `daemon` for all
-  relevant repository, e.g
+  relevant repositories, e.g
     ~~~
     repo gitolite-admin
         - = daemon
@@ -119,16 +119,16 @@ git commit -am "initial"
 
 * For each repo:
     * a user must be authorized according to needed access
-    * `map-anonhttp` option define autorized host or IPs for which `anonhttp` is
+    * `map-anonhttp` option defines a autorized hosts or IPs for which `anonhttp` is
       replaced with this user
 
 ### anonhttp
 
-This user is used with anonymous http access. User is replaced only with an
+This user is used with anonymous http access. The user is replaced only with an
 anonymous connexion. Indeed, if the connexion is already authenticated, it's
 uncesserary to authenticate further.
 
-Default value is `%RC{HTTP_ANON_USER}` or `anonhttp` in this order.
+The default value is `%RC{HTTP_ANON_USER}` or `anonhttp` in this order.
 
 ### option map-anonhttp
 
@@ -150,13 +150,13 @@ Note: This design has been suggested by Sitaram Chamarty, with the option name
 valid and supported.
 
 Note: The syntaxes `*.domain` and `hostname.*` are also supported and are
-equivalent to `.domain` and `hostname`, respectively
+equivalent to `.domain` and `hostname`, respectively.
 
 ### option match-repo
 
-This option allows to match an host based on the name of the repo. First, the
+This option matches a host based on the name of the repo. First, the
 repo name is matched with the match-repo regex. If successful, the host is built
-with numeric groups from the regex.
+from capture groups from the regex.
 
 Example:
 ~~~


### PR DESCRIPTION
To be honest, there wasn't much to fix here. It was all very good. Much better than my French would have been.

Perhaps some additional clarification needs to be made here in both languages.

"Ce user est celui qui identifie les connexions http anonymes. C'est uniquement si la connexion est anonyme qu'une traduction du nom d'utilisateur est faite.

En effet, on considère que si la connexion n'est pas anonyme, alors il n'est pas nécessaire d'authentifier plus encore."

The authenticated user is never "promoted" to the privileges of the anonymous user, even if the anonymous user's privileges are higher. (It is possible, I imagine, that an authenticated user could have lower privileges than an anonymous user from the same host.)